### PR TITLE
Added metadata extraction

### DIFF
--- a/notebooks/metadata.ipynb
+++ b/notebooks/metadata.ipynb
@@ -1,0 +1,127 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# def get_metadata(pdf_link):\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Classification: TT_RBC_Internal\n",
+      "/Company: Royal Bank of Canada\n",
+      "/CreationDate: D:20240226125308-05'00'\n",
+      "/Creator: Acrobat PDFMaker 23 for Word\n",
+      "/EDOID: 1707892\n",
+      "/Keywords: RBC Internal\n",
+      "/ModDate: D:20240226125333-05'00'\n",
+      "/Producer: Adobe PDF Library 23.6.156\n",
+      "/SourceModified: D:20240226175254\n",
+      "/Title: Royal Bank of Canada Earnings Release\n"
+     ]
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "from PyPDF2 import PdfReader\n",
+    "from io import BytesIO\n",
+    "\n",
+    "# Step 1: Download the PDF from the given link\n",
+    "url = \"https://www.rbc.com/investor-relations/_assets-custom/pdf/2024q1release.pdf\"\n",
+    "response = requests.get(url)\n",
+    "\n",
+    "# Load the PDF into PdfReader. THe path can directly be given if it is already downloaded\n",
+    "pdf_file = BytesIO(response.content)\n",
+    "reader = PdfReader(pdf_file)\n",
+    "\n",
+    "#Extract document properties with inbuilt function\n",
+    "pdf_metadata = reader.metadata\n",
+    "\n",
+    "# Display metadata properties\n",
+    "for key, value in pdf_metadata.items():\n",
+    "    print(f\"{key}: {value}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests \n",
+    "from PyPDF2 import PdfReader\n",
+    "import os\n",
+    "import csv\n",
+    "def save_metadata(csv_path,pdf_path):\n",
+    "\n",
+    "    reader = PdfReader(pdf_path)\n",
+    "\n",
+    "    # Extracting pdf properties\n",
+    "    pdf_metadata = reader.metadata\n",
+    "\n",
+    "    headers = list(pdf_metadata.keys())\n",
+    "\n",
+    "    #checking if the csv exist in the path\n",
+    "    csv_exist = os.path.exists(csv_path)\n",
+    "\n",
+    "    with open(csv_path, 'a' if csv_exist else 'w', newline='') as csvfile:\n",
+    "        writer = csv.DictWriter(csvfile, fieldnames=headers)\n",
+    "    \n",
+    "        # Write the header only if the file doesn't exist\n",
+    "        if not csv_exist:\n",
+    "            writer.writeheader({headers})\n",
+    "\n",
+    "        writer.writerow(pdf_metadata) #'The metadata has / in the front'\n",
+    "    # print(pdf_metadata['/Author'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_metadata('../data/metadata.csv',BytesIO(requests.get('https://www.rbc.com/investor-relations/_assets-custom/pdf/ar_2000_e.pdf').content))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The code is there to extract the metadata from the pdf files. We are using the inbuild properties to get the data information. Works with most banks except TD. And all of the pdfs have different properties so we need to find a way to store them. Here I am using csv, which is not recommended at all. I was thinking maybe use llama to send request asking a prompt like 'What is the titlle of the pdf ' by passing few first pages of the pdf. Please let me know if i should  do that